### PR TITLE
fix: update FROM clause in stg_order_items.sql

### DIFF
--- a/models/staging/stg_order_items.sql
+++ b/models/staging/stg_order_items.sql
@@ -9,4 +9,4 @@ select
     "注文ID" as order_id,
     "商品ID" as product_id,
     "数量" as quantity
-from ??????????????
+from {{ source('main', '注文明細') }}


### PR DESCRIPTION
### **User description**
Fixes #6

Updated the FROM clause in `stg_order_items.sql` to reference the correct source table `注文明細` instead of placeholder question marks.

Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
bug_fix


___

### **Description**
- `stg_order_items.sql`のFROM句を修正

- 正しいテーブル`注文明細`を参照


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["stg_order_items.sql"] -- "FROM句修正" --> B["注文明細"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>stg_order_items.sql</strong><dd><code>FROM句の修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

models/staging/stg_order_items.sql

- FROM句を修正
- プレースホルダーを正しいテーブルに変更


</details>


  </td>
  <td><a href="https://github.com/RyutoYoda/dbt-core-demo-cafe/pull/7/files#diff-5d7ead09b3a764791f6c950a657d3729d18af1af1557a454782e6d3b2f008244">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

